### PR TITLE
sets colourlovers request to https to fix the demo page

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -27790,7 +27790,7 @@
 	};
 	
 	var getPalleteFromColorLovers = function getPalleteFromColorLovers(callback) {
-	  jsonp('http://www.colourlovers.com/api/palettes/random?format=json&jsonCallback=callback', {
+	  jsonp('https://www.colourlovers.com/api/palettes/random?format=json&jsonCallback=callback', {
 	    param: 'jsonCallback'
 	  }, callback);
 	};

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -29,7 +29,7 @@ var fixMyColors = (colorScheme, overlayColor, overlayIntensity) => {
 }
 
 var getPalleteFromColorLovers = (callback) => {
-  jsonp('http://www.colourlovers.com/api/palettes/random?format=json&jsonCallback=callback', {
+  jsonp('https://www.colourlovers.com/api/palettes/random?format=json&jsonCallback=callback', {
     param: 'jsonCallback'
   }, callback)
 }


### PR DESCRIPTION
The demo page isn't working due to a mixed content warning:

"Mixed Content: The page at 'https://javierbyte.github.io/cohesive-colors/' was loaded over HTTPS, but requested an insecure script 'http://www.colourlovers.com/api/palettes/random?format=json&jsonCallback=callback&jsonCallback=__jp0'. This request has been blocked; the content must be served over HTTPS."

I literally just changed the http to https, hope this fixes the demo!
